### PR TITLE
Fix the nav menu overlapping in mobile

### DIFF
--- a/styles/lxqt.scss
+++ b/styles/lxqt.scss
@@ -189,7 +189,6 @@
 		{
 			display: none;
 			clear: both;
-			height: 3em;
 			margin: 0;
 			padding: 0.5em;
 			


### PR DESCRIPTION
Part of navigation menu was cut from the page. It is fixed.
**Before**
![before](https://user-images.githubusercontent.com/2451833/55686454-028ca080-597f-11e9-9c9a-a0fcba0f3d2a.png)

**After**
![after](https://user-images.githubusercontent.com/2451833/55686453-028ca080-597f-11e9-972d-faa8993e7e76.png)

