### PR TITLE
Use custom domain and fix URLs

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+lxqt-project.org

--- a/_config.yml
+++ b/_config.yml
@@ -6,38 +6,38 @@ description: The Lightweight Qt Desktop Environment
 # Settings
 url: 'https://lxqt-project.org/'
 collections:
-    downloads:
-        output: true
-        permalink: /downloads/:path/
-    screenshots:
-        output: true
-        permalink: /screenshots/:path/
+  downloads:
+    output: true
+    permalink: /downloads/:path/
+  screenshots:
+    output: true
+    permalink: /screenshots/:path/
 defaults:
-    -
-        scope:
-            path: ''
-        values:
-            unrelimp: null
-            relimp: null
-            relunimp: null
-            unrelunimp:
-                - links.html
-                - downloads.html
-    -
-        scope:
-            path: ''
-            type: downloads
-        values:
-            unrelunimp:
-                - screenshots.html
+  -
+    scope:
+      path: ''
+    values:
+      unrelimp: null
+      relimp: null
+      relunimp: null
+      unrelunimp:
+        - links.html
+        - downloads.html
+  -
+    scope:
+      path: ''
+      type: downloads
+    values:
+      unrelunimp:
+        - screenshots.html
 theme: null
 encoding: 'utf-8'
 kramdown:
-    input: GFM
-    hard_wrap: false
+  input: GFM
+  hard_wrap: false
 sass:
-    sass_dir: styles
-    style: compressed
+  sass_dir: styles
+  style: compressed
 permalink: pretty
 exclude:
   - CNAME

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ strapline: The Lightweight Qt Desktop Environment
 description: The Lightweight Qt Desktop Environment
 
 # Settings
-url: 'https://lxqt.github.io'
+url: 'https://lxqt-project.org/'
 collections:
     downloads:
         output: true
@@ -40,6 +40,7 @@ sass:
     style: compressed
 permalink: pretty
 exclude:
+  - CNAME
   - LICENSE
   - README.md
   - Gemfile

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -8,53 +8,53 @@
     <main>
       <!--<ul>{% for download in site.downloads %}{% if download.promoted %}
         <li>
-          <p><a href="{{ download.url }}" title="{{ download.title }}"><span class="label">{{ download.label }}</span> <img src="{{ download.icon.src }}" alt="{{ download.icon.alt }}"/></a></p>
+          <p><a href="{{ download.url | relative_url }}" title="{{ download.title }}"><span class="label">{{ download.label }}</span> <img src="{{ download.icon.src | relative_url }}" alt="{{ download.icon.alt }}"/></a></p>
         </li>{% endif %}{% endfor %}
       </ul>-->
       <ul>
         <li>
-          <p><a href="https://github.com/lxqt"><span class="label">GitHub</span> <img src="/images/github-logo-22.png" title="GitHub repository" alt="GitHub"></a></p>
+          <p><a href="https://github.com/lxqt"><span class="label">GitHub</span> <img src="{{ '/images/github-logo-22.png' | relative_url }}" title="GitHub repository" alt="GitHub"></a></p>
         </li>
         <!--
         <li>
-          <p><a href="https://downloads.lxqt.org/current.html"><span class="label">Source downloads</span> <img src="/images/source-22.png" title="Source downloads" alt="Source"></a></p>
+          <p><a href="https://downloads.lxqt.org/current.html"><span class="label">Source downloads</span> <img src="{{ '/images/source-22.png' | relative_url }}" title="Source downloads" alt="Source"></a></p>
         </li>
         -->
         <li>
-          <p><a href="https://packages.altlinux.org/en/search?query=lxqt"><span class="label">ALT Linux</span> <img src="/images/altlinux-logo-22.png" title="ALT packages" alt="ALT Linux"></a></p>
+          <p><a href="https://packages.altlinux.org/en/search?query=lxqt"><span class="label">ALT Linux</span> <img src="{{ '/images/altlinux-logo-22.png' | relative_url }}" title="ALT packages" alt="ALT Linux"></a></p>
         </li>
         <li>
-          <p><a href="https://www.archlinux.org/groups/x86_64/lxqt/"><span class="label">Arch Linux</span> <img src="/images/archlinux-logo-22.png" title="Arch [community] packages" alt="Arch Linux"></a></p>
+          <p><a href="https://www.archlinux.org/groups/x86_64/lxqt/"><span class="label">Arch Linux</span> <img src="{{ '/images/archlinux-logo-22.png' | relative_url }}" title="Arch [community] packages" alt="Arch Linux"></a></p>
         </li>
         <li>
-            <p><a href="http://sourceforge.net/projects/lxqt-for-chakra/"><span class="label">Chakra</span> <img src="/images/chakra-logo-22.png" title="Chakra" alt="Chakra" /></a></p>
+            <p><a href="https://sourceforge.net/projects/lxqt-for-chakra/"><span class="label">Chakra</span> <img src="{{ '/images/chakra-logo-22.png' | relative_url }}" title="Chakra" alt="Chakra" /></a></p>
         </li>
         <li>
-          <p><a href="https://packages.debian.org/sid/lxqt"><span class="label">Debian</span> <img src="/images/debian-logo-22.png" title="Debian metapackage" alt="Debian"></a></p>
+          <p><a href="https://packages.debian.org/sid/lxqt"><span class="label">Debian</span> <img src="{{ '/images/debian-logo-22.png' | relative_url }}" title="Debian metapackage" alt="Debian"></a></p>
         </li>
         <li>
-          <p><a href="https://spins.fedoraproject.org/en/lxqt/"><span class="label">Fedora</span> <img src="/images/fedora-logo-22.png" title="Fedora spin" alt="Fedora"></a></p>
+          <p><a href="https://spins.fedoraproject.org/en/lxqt/"><span class="label">Fedora</span> <img src="{{ '/images/fedora-logo-22.png' | relative_url }}" title="Fedora spin" alt="Fedora"></a></p>
         </li>
         <li>
-          <p><a href="https://packages.gentoo.org/package/lxqt-base/lxqt-meta"><span class="label">Gentoo</span> <img src="/images/gentoo-logo-22.png" title="Gentoo overlay" alt="Gentoo"></a></p>
+          <p><a href="https://packages.gentoo.org/package/lxqt-base/lxqt-meta"><span class="label">Gentoo</span> <img src="{{ '/images/gentoo-logo-22.png' | relative_url }}" title="Gentoo overlay" alt="Gentoo"></a></p>
         </li>
         <li>
-          <p><a href="https://madb.mageia.org/package/show/application/0/name/task-lxqt"><span class="label">Mageia</span> <img src="/images/mageia-logo-22.png" title="Mageia metapackage" alt="Mageia"></a></p>
+          <p><a href="https://madb.mageia.org/package/show/application/0/name/task-lxqt"><span class="label">Mageia</span> <img src="{{ '/images/mageia-logo-22.png' | relative_url }}" title="Mageia metapackage" alt="Mageia"></a></p>
         </li>
         <li>
-          <p><a href="https://osdn.net/projects/manjaro-community/storage/lxqt/"><span class="label">Manjaro</span> <img src="/images/manjaro-logo-22.png" title="Manjaro ISOs" alt="Manjaro"></a></p>
+          <p><a href="https://osdn.net/projects/manjaro-community/storage/lxqt/"><span class="label">Manjaro</span> <img src="{{ '/images/manjaro-logo-22.png' | relative_url }}" title="Manjaro ISOs" alt="Manjaro"></a></p>
         </li>
         <li>
-          <p><a href="https://abf.openmandriva.org/openmandriva/task-lxqt/build_lists"><span class="label">OpenMandriva</span> <img src="/images/openmandriva-logo-22.png" title="OpenMandriva metapackage" alt="OpenMandriva Lx"></a></p>
+          <p><a href="https://abf.openmandriva.org/openmandriva/task-lxqt/build_lists"><span class="label">OpenMandriva</span> <img src="{{ '/images/openmandriva-logo-22.png' | relative_url }}" title="OpenMandriva metapackage" alt="OpenMandriva Lx"></a></p>
         </li>
         <li>
-          <p><a href="http://wiki.rosalab.ru/en/index.php/LXQt"><span class="label">ROSA Linux</span> <img src="/images/rosa-linux-22.png" title="Information about LXQt in ROSA Linux" alt="ROSA Linux"></a></p>
+          <p><a href="http://wiki.rosalab.ru/en/index.php/LXQt"><span class="label">ROSA Linux</span> <img src="{{ '/images/rosa-linux-22.png' | relative_url }}" title="Information about LXQt in ROSA Linux" alt="ROSA Linux"></a></p>
         </li>
         <li>
-          <p><a href="https://en.opensuse.org/LXQT"><span class="label">openSUSE</span> <img src="/images/opensuse-logo-22.png" title="openSUSE packages" alt="openSUSE"></a></p>
+          <p><a href="https://en.opensuse.org/LXQT"><span class="label">openSUSE</span> <img src="{{ '/images/opensuse-logo-22.png' | relative_url }}" title="openSUSE packages" alt="openSUSE"></a></p>
         </li>
         <li>
-          <p><a href="http://lubuntu.me/"><span class="label">Ubuntu</span> <img src="/images/ubuntu-logo-22.png" title="The *official* Lubuntu website" alt="Ubuntu"></a></p>
+          <p><a href="https://lubuntu.me/"><span class="label">Ubuntu</span> <img src="{{ '/images/ubuntu-logo-22.png' | relative_url }}" title="The *official* Lubuntu website" alt="Ubuntu"></a></p>
         </li>
       </ul>
     </main>

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -56,7 +56,7 @@
                     <p>Feed RSS</p>
                 </dt>
                 <dd>
-                    <p><a href="https://lxqt.github.io/feed">https://lxqt.github.io/feed</a></p>
+                    <p><a href="{{ '/feed.xml' | absolute_url }}">{{ '/feed.xml' | absolute_url | replace_first: 'https://','' | replace_first: 'http://','' }}</a></p>
                 </dd>
             </dl>
         </main>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,24 +6,24 @@
          <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>
          <title>{% if page.title %}{{ page.title}} | {{ site.title }}{% else %}{{ site.title }} - {{ site.strapline }}{% endif %}</title>
          <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}"/>
-         <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}"/>
-         <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="/feed.xml"/>
-         <link type="text/css" href="/styles/lxqt.css" rel="stylesheet"/>
-         <link rel="shortcut icon" href="/images/favicon.png" type="image/png"/>
-         <script type="text/javascript" src="/scripts/@module.js"></script>
-         <script type="text/javascript" src="/scripts/lxqt.js"></script>
+         <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}"/>
+         <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ '/feed.xml' | absolute_url }}"/>
+         <link type="text/css" href="{{ '/styles/lxqt.css' | relative_url }}" rel="stylesheet"/>
+         <link rel="shortcut icon" href="{{ '/images/favicon.png' | relative_url }}" type="image/png"/>
+         <script type="text/javascript" src="{{ '/scripts/@module.js' | relative_url }}"></script>
+         <script type="text/javascript" src="{{ '/scripts/lxqt.js' | relative_url }}"></script>
     </head>
     <body id="org-lxqt" data-columns="2" itemscope itemtype="http://schema.org/Organization">
         <header id="intro">
             <hgroup id="heading">
                 <h1 itemprop="brand" itemscope itemtype="http://schema.org/Brand">
-                    <a href="{{ site.url }}" itemprop="url">
+                    <a href="{{ '/' | absolute_url }}" itemprop="url">
                         <img src="/images/lxqt-white.png" title="{{ site.title }}" alt="{{ site.title }}" itemprop="logo"/>
                         <span itemprop="name">{{ site.title }}</span>
 		    </a>
                 </h1>
             </hgroup>
-            <p class="button action"><button data-action="state.toggle" data-target="#nav"><img src="/images/webapp-icon-action-menu.svg"/></button></p>
+            <p class="button action"><button data-action="state.toggle" data-target="#nav"><img src="{{ '/images/webapp-icon-action-menu.svg' | relative_url }}"/></button></p>
             <p class="strapline"><strong><span>{{ site.strapline }}</span></strong></p>
             <nav id="nav" data-state="inert">
                 <header>
@@ -34,13 +34,13 @@
                 <div class="wrapper">
                     <main>
                         <ul>
-                            <li><p><a href="/about/">About</a></p></li>
-                            <!--<li><p><a href="https://blog.lxqt.org">Blog</a></p></li>-->
-                            <!--<li><p><a href="https://forum.lxqt.org">Forum</a></p></li>-->
-                            <li><p><a href="/releases/">Releases</a></p></li>
-                            <li><p><a href="/downloads/">Downloads</a></p></li>
-                            <li><p><a href="/screenshots/">Screenshots</a></p></li>
-                            <li><p><a href="https://translate.lxqt-project.org">Translations</a></p></li>
+                            <li><p><a href="{{ '/about/' | relative_url }}">About</a></p></li>
+                            <!--<li><p><a href="{{ site.url | replace_first: 'https://','https://blog.' | replace_first: 'http://','http://blog.' }}">Blog</a></p></li>-->
+                            <!--<li><p><a href="{{ site.url | replace_first: 'https://','https://forum.' | replace_first: 'http://','http://forum.' }}">Forum</a></p></li>-->
+                            <li><p><a href="{{ '/releases/' | relative_url }}">Releases</a></p></li>
+                            <li><p><a href="{{ '/downloads/' | relative_url }}">Downloads</a></p></li>
+                            <li><p><a href="{{ '/screenshots/' | relative_url }}">Screenshots</a></p></li>
+                            <li><p><a href="{{ site.url | replace_first: 'https://','https://translate.' | replace_first: 'http://','http://translate.' }}">Translations</a></p></li>
                             <li><p><a href="https://github.com/lxqt/lxqt/blob/master/CONTRIBUTING.md">Contribute</a></p></li>
                         </ul>
                     </main>

--- a/_layouts/screenshot.html
+++ b/_layouts/screenshot.html
@@ -9,7 +9,7 @@ layout: default
 	</header>
 	<div class="wrapper">
 		<main>
-			<a href="{{page.src}}"><img src="{{ page.src }}" alt="{{ page.alt }}"/></a>
+			<a href="{{ page.src | relative_url }}"><img src="{{ page.src | relative_url }}" alt="{{ page.alt }}"/></a>
 		</main>
 		<footer>{{ post.caption }}</footer>
 	</div>

--- a/_screenshots/ambiance.html
+++ b/_screenshots/ambiance.html
@@ -6,4 +6,4 @@ src: /images/screenshots/ambiance.png
 alt: The LXQt Ambiance theme
 promoted: true
 ---
-<img src="{{ page.src }}" alt="{{ page.alt }}"/>
+<img src="{{ page.src | relative_url }}" alt="{{ page.alt }}"/>

--- a/_screenshots/dark.html
+++ b/_screenshots/dark.html
@@ -6,4 +6,4 @@ src: /images/screenshots/dark.png
 alt: The LXQt Dark theme
 promoted: true
 ---
-<img src="{{ page.src }}" alt="{{ page.alt }}"/>
+<img src="{{ page.src | relative_url }}" alt="{{ page.alt }}"/>

--- a/_screenshots/frost.html
+++ b/_screenshots/frost.html
@@ -6,4 +6,4 @@ src: /images/screenshots/frost.png
 alt: The LXQt Frost theme
 promoted: true
 ---
-<img src="{{ page.src }}" alt="{{ page.alt }}"/>
+<img src="{{ page.src | relative_url }}" alt="{{ page.alt }}"/>

--- a/_screenshots/plasma.html
+++ b/_screenshots/plasma.html
@@ -6,4 +6,4 @@ src: /images/screenshots/plasma.png
 alt: The KDE Plasma theme
 promoted: true
 ---
-<img src="{{ page.src }}" alt="{{ page.alt }}"/>
+<img src="{{ page.src | relative_url }}" alt="{{ page.alt }}"/>

--- a/feed.xml
+++ b/feed.xml
@@ -6,8 +6,8 @@ layout: null
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}{{ site.baseurl }}/</link>
-    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <link>{{ '/' | absolute_url }}</link>
+    <atom:link href="{{ '/feed.xml' | absolute_url }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
@@ -16,8 +16,8 @@ layout: null
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <link>{{ post.url | absolute_url }}</link>
+        <guid isPermaLink="true">{{ post.url | absolute_url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}

--- a/feed.xml
+++ b/feed.xml
@@ -3,28 +3,28 @@ layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>{{ site.title | xml_escape }}</title>
-    <description>{{ site.description | xml_escape }}</description>
-    <link>{{ '/' | absolute_url }}</link>
-    <atom:link href="{{ '/feed.xml' | absolute_url }}" rel="self" type="application/rss+xml"/>
-    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
-    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
-    <generator>Jekyll v{{ jekyll.version }}</generator>
-    {% for post in site.posts limit:10 %}
-      <item>
-        <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | absolute_url }}</link>
-        <guid isPermaLink="true">{{ post.url | absolute_url }}</guid>
-        {% for tag in post.tags %}
-        <category>{{ tag | xml_escape }}</category>
-        {% endfor %}
-        {% for cat in post.categories %}
-        <category>{{ cat | xml_escape }}</category>
-        {% endfor %}
-      </item>
-    {% endfor %}
-  </channel>
+	<channel>
+		<title>{{ site.title | xml_escape }}</title>
+		<description>{{ site.description | xml_escape }}</description>
+		<link>{{ '/' | absolute_url }}</link>
+		<atom:link href="{{ '/feed.xml' | absolute_url }}" rel="self" type="application/rss+xml"/>
+		<pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+		<lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+		<generator>Jekyll v{{ jekyll.version }}</generator>
+		{% for post in site.posts limit:10 %}
+		<item>
+			<title>{{ post.title | xml_escape }}</title>
+			<description>{{ post.content | xml_escape }}</description>
+			<pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+			<link>{{ post.url | absolute_url }}</link>
+			<guid isPermaLink="true">{{ post.url | absolute_url }}</guid>
+			{% for tag in post.tags %}
+			<category>{{ tag | xml_escape }}</category>
+			{% endfor %}
+			{% for cat in post.categories %}
+			<category>{{ cat | xml_escape }}</category>
+			{% endfor %}
+		</item>
+		{% endfor %}
+	</channel>
 </rss>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ slug: home
 			<div class="wrapper">
 				<main>
 					{{ post.excerpt }}
-                                        <a href="{{ post.url | relative_url }}">Read more...</a>
+					<a href="{{ post.url | relative_url }}">Read more...</a>
 				</main>
 				<footer>{% if post.meta %}<p class="meta">{{ post.meta }}</p>{% endif %}</footer>
 			</div>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ slug: home
 ---
 <ol id="article-{{ page.slug }}_preview">{% for screenshot in site.screenshots limit:5 %}{% if screenshot.promoted %}
 	<li data-state="inert">
-		<a href="{{ screenshot.url }}" title="{{ screenshot.title }}">
+		<a href="{{ screenshot.url | relative_url }}" title="{{ screenshot.title }}">
 			<figure id="article-{{ page.slug }}_preview_{{ screenshot.slug }}" data-action="state.shift.up" data-state="none">
 				<header>
 					<hgroup>
@@ -13,7 +13,7 @@ slug: home
 				</header>
 				<div class="wrapper">
 					<main>
-						<img src="{{ screenshot.src }}" alt="{{ screenshot.alt }}"/>
+						<img src="{{ screenshot.src | relative_url }}" alt="{{ screenshot.alt }}"/>
 					</main>
 				</div>
 			</figure>
@@ -26,13 +26,13 @@ slug: home
 		<article id="article-{{ post.slug }}" class="post">
 			<header>
 				<hgroup>
-					<h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
+					<h1><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h1>
 				</hgroup>
 			</header>
 			<div class="wrapper">
 				<main>
 					{{ post.excerpt }}
-                                        <a href="{{ post.url }}">Read more...</a>
+                                        <a href="{{ post.url | relative_url }}">Read more...</a>
 				</main>
 				<footer>{% if post.meta %}<p class="meta">{{ post.meta }}</p>{% endif %}</footer>
 			</div>

--- a/releases.html
+++ b/releases.html
@@ -7,7 +7,7 @@ slug: releases
 <article id="article-{{ post.slug }}" class="post">
 	<header>
 		<hgroup>
-			<h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
+			<h1><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h1>
 		</hgroup>
 		<p class="date"><time datetime="{{ post.date | date: '%F %R' }}">{{ post.date | date: '%A, %-d %B, %Y' }}</time></p>
 		{% if post.author %}<p class="author">{{ post.author }}</p>{% endif %}

--- a/screenshots.html
+++ b/screenshots.html
@@ -6,7 +6,7 @@ slug: screenshots
 <ol>
 {% for screenshot in site.screenshots %}{% if screenshot.promoted %}
 	<li>
-		<a href="{{ screenshot.url }}" title="{{ screenshot.title }}">
+		<a href="{{ screenshot.url | relative_url }}" title="{{ screenshot.title }}">
 			<figure>
 				<header>
 					<hgroup>
@@ -15,7 +15,7 @@ slug: screenshots
 				</header>
 				<div class="wrapper">
 					<main>
-						<img src="{{ screenshot.src }}" alt="{{ screenshot.alt }}"/>
+						<img src="{{ screenshot.src | relative_url }}" alt="{{ screenshot.alt }}"/>
 					</main>
 					<footer>{{ screenshot.caption }}</footer>
 				</div>


### PR DESCRIPTION
This pull request addresses #48 by adding a custom domain to it.

GitHub will generate a SSL certificate and redirect the `.github.io` domain to the one specified in the `CNAME` file.

However, some `A` records need to be added first, one for each GitHub Pages IP, and optionally a `CNAME` record to the `www` subdomain.

That would automatically redirect `www.lxqt-project.org` to ` lxqt-project.org`.

The option "Enforce HTTPS" would probably need to be enabled in the repository settings.

More information: [Configuring an apex domain](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain)

- [x] Generate `CNAME` file to use a custom domain
- [x] Use the apex domain `lxqt-project.org` to generate absolute URLs.
- [x] Fix internal relative and absolute URLs
- [x] Minor fixes in `_config.yml`

Fixes #48