### PR TITLE
Remove trailing forward slash in URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ strapline: The Lightweight Qt Desktop Environment
 description: The Lightweight Qt Desktop Environment
 
 # Settings
-url: 'https://lxqt-project.org/'
+url: 'https://lxqt-project.org'
 collections:
   downloads:
     output: true


### PR DESCRIPTION
I accidentally introduced some issues with the URLs in #50 (sorry!)

Due to an unfixed bug (https://github.com/jekyll/jekyll/issues/6947) if the domain in the `_config.yml` file ends with a forward slash, it will produce URLs with an extra forward slash.

It doesn't seem to affect post URLs in the homepage, however, the feed produces URLs like:

```xml
<link>https://lxqt-project.org//release/2020/11/05/lxqt-0-16-0/</link>
```