### PR TITLE
Change email list to GitHub Discussions page

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -8,12 +8,10 @@
         <main>
             <dl>
                 <dt>
-                    <p>Mailing List</p>
+                    <p>Discussion</p>
                 </dt>
                 <dd>
-                    <address class="email" itemprop="contactpoint" itemscope itemtype="http://schema.org/ContactPoint">
-                        <p><a href="https://lists.sourceforge.net/lists/listinfo/lxde-list" itemprop="email">lxde-list@lists.sourceforge.net</a></p>
-                    </address>
+                    <p><a href="https://github.com/lxqt/lxqt/discussions">github.com/lxqt/lxqt/discussions</a></p>
                 </dd>
                 <!--
                 <dt>


### PR DESCRIPTION
 * removed all the address class business since it's not an email address
 * changed "Mailing List" to "Discussion" to be a little more general in description