### PR TITLE
Add link for Matrix room.

### DIFF
--- a/_includes/links.html
+++ b/_includes/links.html
@@ -42,6 +42,12 @@
                     <p><a href="https://github.com/lxqt/lxqt/wiki">github.com/lxqt/lxqt</a></p>
                 </dd>
                 <dt>
+                    <p>Telegram</p>
+                </dt>
+                <dd>
+                    <p><a href="https://t.me/lxqtofficial">LXQt official</a></p>
+                </dd>
+                <dt>
                     <p>Matrix</p>
                 </dt>
                 <dd>

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -42,19 +42,19 @@
                     <p><a href="https://github.com/lxqt/lxqt/wiki">github.com/lxqt/lxqt</a></p>
                 </dd>
                 <dt>
-                    <p>Telegram</p>
+                    <p>Telegram<i>Bridged to Matrix and IRC</i></p>
                 </dt>
                 <dd>
                     <p><a href="https://t.me/lxqtofficial">LXQt official</a></p>
                 </dd>
                 <dt>
-                    <p>Matrix</p>
+                    <p>Matrix<i>Bridged to Telegram and IRC</i></p>
                 </dt>
                 <dd>
                     <p><a href="https://matrix.to/#/#lxqt:matrix.org">#lxqt:matrix.org</a></p>
                 </dd>
                 <dt>
-                    <p>IRC</p>
+                    <p>IRC<i>Bridged to Matrix and Telegram</i></p>
                 </dt>
                 <dd>
                     <p>#lxqt on <a href="http://www.oftc.net/">OFTC</a> for user support</p>

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -42,6 +42,12 @@
                     <p><a href="https://github.com/lxqt/lxqt/wiki">github.com/lxqt/lxqt</a></p>
                 </dd>
                 <dt>
+                    <p>Matrix</p>
+                </dt>
+                <dd>
+                    <p><a href="https://matrix.to/#/#lxqt:matrix.org">#lxqt:matrix.org</a></p>
+                </dd>
+                <dt>
                     <p>IRC</p>
                 </dt>
                 <dd>

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -42,19 +42,19 @@
                     <p><a href="https://github.com/lxqt/lxqt/wiki">github.com/lxqt/lxqt</a></p>
                 </dd>
                 <dt>
-                    <p>Telegram<i>Bridged to Matrix and IRC</i></p>
+                    <p>Telegram <i>Bridged to Matrix and IRC</i></p>
                 </dt>
                 <dd>
                     <p><a href="https://t.me/lxqtofficial">LXQt official</a></p>
                 </dd>
                 <dt>
-                    <p>Matrix<i>Bridged to Telegram and IRC</i></p>
+                    <p>Matrix <i>Bridged to Telegram and IRC</i></p>
                 </dt>
                 <dd>
                     <p><a href="https://matrix.to/#/#lxqt:matrix.org">#lxqt:matrix.org</a></p>
                 </dd>
                 <dt>
-                    <p>IRC<i>Bridged to Matrix and Telegram</i></p>
+                    <p>IRC <i>Bridged to Matrix and Telegram</i></p>
                 </dt>
                 <dd>
                     <p>#lxqt on <a href="http://www.oftc.net/">OFTC</a> for user support</p>


### PR DESCRIPTION
Per the [discussion](https://github.com/lxqt/lxqt/discussions/1923), I learned of the Matrix room. I think it would be good to add the room to the links on the web page to give it some more visibility.