### PR TITLE
Simpler description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Meta
 title: LXQt
-strapline: The Lightweight Qt Desktop Environment
-description: The Lightweight Qt Desktop Environment
+strapline: A light desktop environment
+description: A light desktop environment
 
 # Settings
 url: 'https://lxqt-project.org'


### PR DESCRIPTION
Proclaiming "_The_" lightweight Qt desktop is arrogant in itself. Moreover it is also not in a lot of competition as of now.
"Qt" is right there in the name, for those that know what Qt even is.
Focusing on a wider audience is better for everyone.
