### PR TITLE
Point releases 1.2.1 postings

### DIFF
--- a/_posts/2023-01-02-libfm-qt-1.2.1.md
+++ b/_posts/2023-01-02-libfm-qt-1.2.1.md
@@ -2,7 +2,7 @@
 layout: post
 title: Release libfm-qt 1.2.1
 slug: libfm-qt-1-2-1
-date: 2022-12-31 12:58
+date: 2023-01-02 08:17
 promoted: false
 categories: release
 ---

--- a/_posts/2023-01-02-libfm-qt-1.2.1.md
+++ b/_posts/2023-01-02-libfm-qt-1.2.1.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: Release libfm-qt 1.2.1
+slug: libfm-qt-1-2-1
+date: 2022-12-31 12:58
+promoted: false
+categories: release
+---
+
+The LXQt team announces the point release of libfm-qt 1.2.1.
+The release can be downloaded from [Github](https://github.com/lxqt/libfm-qt/releases).
+
+Changes:
+
+ * Specified the parents of context menus for use on Wayland.
+ * Fixed launching XWayland apps under Wayland.
+ * appchooserdialog: do not disable the OK button when Custom Command page is shown.
+ * Increased the minimum width of name column in detailed list view.
+ * Fixed the DND menu position under Wayland.
+ * Fixed crash with DND from outside app under Wayland.
+ * Fixed unresponsive DND menu under Wayland.
+ * Workaround for DND keyboard modifiers under Wayland.
+ * Check mime data of clipboard for nullity (for Wayland).
+ * Fixed drawing of selection rectangle under Wayland.
+
+
+<br/>
+A full list of changes is in the CHANGELOG file.
+<br/>

--- a/_posts/2023-01-02-lxqt-panel-1.2.1.md
+++ b/_posts/2023-01-02-lxqt-panel-1.2.1.md
@@ -2,7 +2,7 @@
 layout: post
 title: Release lxqt-panel 1.2.1
 slug: lxqt-panel-1-2-1
-date: 2022-12-31 14:48
+date: 2023-01-02 08:12
 promoted: false
 categories: release
 ---

--- a/_posts/2023-01-02-lxqt-panel-1.2.1.md
+++ b/_posts/2023-01-02-lxqt-panel-1.2.1.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: Release lxqt-panel 1.2.1
+slug: lxqt-panel-1-2-1
+date: 2022-12-31 14:48
+promoted: false
+categories: release
+---
+The LXQt team announces the point release of lxqt-panel 1.2.1.
+The release can be downloaded from [Github](https://github.com/lxqt/lxqt-panel/releases).
+
+Main changes:
+
+ * Fixed a regression in volume popup.
+ * Added Qeyes plugin.
+ * Avoid covering fullscreen windows.
+
+<br/>
+A full list of changes is in the CHANGELOG file.
+<br/>

--- a/_posts/2023-01-02-pcmanfm-qt-1.2.1.md
+++ b/_posts/2023-01-02-pcmanfm-qt-1.2.1.md
@@ -7,7 +7,7 @@ promoted: false
 categories: release
 ---
 
-The LXQt team announces the point release of pcmanfm-qt 1.2.1.
+The LXQt team announces the point release of PCManFM-Qt 1.2.1.
 The release can be downloaded from [Github](https://github.com/lxqt/pcmanfm-qt/releases).
 
 Changes:

--- a/_posts/2023-01-02-pcmanfm-qt-1.2.1.md
+++ b/_posts/2023-01-02-pcmanfm-qt-1.2.1.md
@@ -2,7 +2,7 @@
 layout: post
 title: Release pcmanfm-qt 1.2.1
 slug: pcmanfm-qt-1-2-1
-date: 2022-12-31 12:59
+date: 2023-01-02 08:16
 promoted: false
 categories: release
 ---

--- a/_posts/2023-01-02-pcmanfm-qt-1.2.1.md
+++ b/_posts/2023-01-02-pcmanfm-qt-1.2.1.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: Release pcmanfm-qt 1.2.1
+slug: pcmanfm-qt-1-2-1
+date: 2022-12-31 12:59
+promoted: false
+categories: release
+---
+
+The LXQt team announces the point release of pcmanfm-qt 1.2.1.
+The release can be downloaded from [Github](https://github.com/lxqt/pcmanfm-qt/releases).
+
+Changes:
+
+ * Corrected the icon for "New Tab".
+ * Corrected some descriptions in Hidden Shortcuts dialog.
+ * Enabled tab DND under Wayland.
+ * Fixed the context menus of tabs and forward/backward buttons under Wayland.
+
+<br/>
+A full list of changes is in the CHANGELOG file.
+<br/>

--- a/_posts/2023-01-02-point-releases-1.2.1.md
+++ b/_posts/2023-01-02-point-releases-1.2.1.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: Three Point Releases
+slug: 3-point-releases
+date: 2022-12-31 14:48
+promoted: true
+categories: blog
+---
+
+The LXQt team has decided to release point releases for three main components:
+
+The main reason for the [point release](https://lxqt-project.org/release/2023/01/02/lxqt-panel-1-2-1/) of lxqt-panel was a change of behavior in xfwm4 version 4.18, which caused full-screen windows to go under the panel. A regression in the volume popup is also fixed and a Qeye plugin has been added.
+
+For libfm-qt the [point release](https://lxqt-project.org/release/2023/01/02/libfm-qt-1-2-1/) provides a smooth Wayland experience with apps that are based on `libfm-qt`, especially PCManFM-Qt. Several problems are fixed regarding Wayland, like context menus, drag-and-drop, and launching of XWayland apps. Also, the minimum width of name column is increased in the detailed list mode.
+
+The [point release](https://lxqt-project.org/release/2023/01/02/pcmanfm-qt-1-2-1/) of pcmanfm-qt was made, alongside the point release of `libfm-qt`, for providing a good Wayland experience before porting both to Qt6. Also, tab drag-and-drop is enabled under Wayland.
+

--- a/_posts/2023-01-02-point-releases-1.2.1.md
+++ b/_posts/2023-01-02-point-releases-1.2.1.md
@@ -2,16 +2,16 @@
 layout: post
 title: Three Point Releases
 slug: 3-point-releases
-date: 2022-12-31 14:48
+date: 2023-01-02 08:12
 promoted: true
 categories: blog
 ---
 
-The LXQt team has decided to make point releases for three main components:
+The LXQt team decided to make point releases for three main components:
 
 The main reason for the [point release](https://lxqt-project.org/release/2023/01/02/lxqt-panel-1-2-1/) of lxqt-panel was a change of behavior in xfwm4 version 4.18, which caused full-screen windows to go under the panel. A regression in the volume popup is also fixed and a Qeye plugin has been added.
 
 For libfm-qt the [point release](https://lxqt-project.org/release/2023/01/02/libfm-qt-1-2-1/) provides a smooth Wayland experience with apps that are based on `libfm-qt`, especially PCManFM-Qt. Several problems are fixed regarding Wayland, like context menus, drag-and-drop, and launching of XWayland apps. Also, the minimum width of name column is increased in the detailed list mode.
 
-The [point release](https://lxqt-project.org/release/2023/01/02/pcmanfm-qt-1-2-1/) of pcmanfm-qt was made, alongside the point release of `libfm-qt`, for providing a good Wayland experience before porting both to Qt6. Also, tab drag-and-drop is enabled under Wayland.
+The [point release](https://lxqt-project.org/release/2023/01/02/pcmanfm-qt-1-2-1/) of PCManFM-Qt was made, alongside the point release of `libfm-qt`, for providing a good Wayland experience before porting both to Qt6. Also, tab drag-and-drop is enabled under Wayland.
 

--- a/_posts/2023-01-02-point-releases-1.2.1.md
+++ b/_posts/2023-01-02-point-releases-1.2.1.md
@@ -7,7 +7,7 @@ promoted: true
 categories: blog
 ---
 
-The LXQt team has decided to release point releases for three main components:
+The LXQt team has decided to make point releases for three main components:
 
 The main reason for the [point release](https://lxqt-project.org/release/2023/01/02/lxqt-panel-1-2-1/) of lxqt-panel was a change of behavior in xfwm4 version 4.18, which caused full-screen windows to go under the panel. A regression in the volume popup is also fixed and a Qeye plugin has been added.
 


### PR DESCRIPTION
One post on the main page, the other three under "releases". Timestamps have to be updated.