### PR TITLE
Qterm* 2.0 releases

### DIFF
--- a/_posts/2024-05-17-qterminal-2.0.0.md
+++ b/_posts/2024-05-17-qterminal-2.0.0.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title: Release QTerminal 2.0.0
+slug: qterminal-2-0-0
+date: 2024-05-16 19:36
+promoted: true
+categories: release
+---
+
+The LXQt team is proud to announce the release of QTerminal 2.0.0, ported to Qt6.
+Also, some fixes are made and the code is cleaned up.
+The release can be downloaded from [Github](https://github.com/lxqt/qterminal/releases).
+
+Changes:
+
+ * Ported to Qt6.
+ * Initialized some variables.
+ * Initialized some members in constructors.
+ * Removed a duplicated `#include`.
+ * Removed nullity test before deleting a pointer.
+ * Used `default` to define trivial constructors.
+ * Added word characters option to preferences.
+ * Fixed inactive tab text with Qt6.
+ * Dropped `qAsConst`.
+ * Improved Qt translations loading.
+ * Removes unused libraries.
+ * Dropped `USE_QTERMWIDGET5/6`.
+ * Silenced Qt6 compilation warnings.
+
+<br/>
+A full list of changes is in the CHANGELOG file.
+<br/>

--- a/_posts/2024-05-17-qtermwidget-2.0.0.md
+++ b/_posts/2024-05-17-qtermwidget-2.0.0.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title: Release qtermwidget 2.0.0
+slug: qtermwidget-2-0-0
+date: 2024-05-16 19:25
+promoted: true
+categories: release
+---
+
+The LXQt team is proud to announce the release of qtermwidget 2.0.0. This library is ported to Qt6, in addition to receiving several fixes, improvements and code cleanups.
+The release can be downloaded from [Github](https://github.com/lxqt/qtermwidget/releases).
+
+Changes:
+
+ * Ported to Qt6.
+ * Used "new" signal/slot syntax.
+ * Dropped `#define` for bulk timeouts.
+ * Removed KDE `#include`s.
+ * Dropped XKB related conditional compilation.
+ * Assigned a parent to bulkTimers.
+ * Removed unused screen artifacts.
+ * Added shortcuts for appscreen `default.keytab`.
+ * Exposed wordCharacters property to QTermWidget API.
+ * Fixed cursor positioning issues.
+ * Removed `ChildProcessSetup` and directly called `onsetupChildProcess`.
+ * Used PyQt6.
+ * Fixed deprecated function warning.
+ * Removed anchored pattern for email and url.
+ * Adapted to Qt6 `QProcess::setChildProcessModifier()`.
+ * Used std library find algorithm.
+ * Fixed comparison of pointer addition with NULL.
+
+
+<br/>
+A full list of changes is in the CHANGELOG file.
+<br/>

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -1031,7 +1031,7 @@ $highlight-color: #EF0 !global;	// #Note: Default yellow-green for highlight col
 	{
 		font-family: monospace;
 		white-space: pre-wrap;
-		font-size: 14px;
+		font-size: 13px;
 		color: #e7d48b;
 	}
 	var.constant	// #Note: Variable (local only)


### PR DESCRIPTION
Added also a fix for code display, tested on firefox and falkon

Before:
![immagine](https://github.com/lxqt/lxqt.github.io/assets/10681413/a0a4b874-13c8-48e3-ba83-f07005abb9d7)

After:

![immagine](https://github.com/lxqt/lxqt.github.io/assets/10681413/dc889779-b537-46b2-828a-ef34770065e4)
