### PR TITLE
Update downloads.html

### DIFF
--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -30,7 +30,7 @@
             <p><a href="https://sourceforge.net/projects/lxqt-for-chakra/"><span class="label">Chakra</span> <img src="{{ '/images/chakra-logo-22.png' | relative_url }}" title="Chakra" alt="Chakra" /></a></p>
         </li>-->
         <li>
-            <p><a href="https://packages.artixlinux.org/?search_criteria=lxqt"><span class="label">Artix</span> <img src="{{ '/images/artix-logo-22.png' | relative_url }}" title="Artix" alt="Artix packages" /></a></p>
+            <p><a href="https://packages.artixlinux.org/?search_criteria=lxqt"><span class="label">Artix</span> <img src="{{ '/images/artix-logo-22.png' | relative_url }}" title="Artix packages" alt="Artix" /></a></p>
         </li>
         <li>
           <p><a href="https://wiki.debian.org/LXQt"><span class="label">Debian</span> <img src="{{ '/images/debian-logo-22.png' | relative_url }}" title="Debian Wiki" alt="Debian"></a></p>
@@ -47,9 +47,9 @@
         <li>
             <p><a href="https://wiki.freebsd.org/LXQt"><span class="label">FreeBSD</span> <img src="{{ '/images/FreeBSD-logo-22.png' | relative_url }}" title="FreeBSD LXQt Wiki" alt="FreeBSD" /></a></p>
         </li>
-        <li>
+        <!--<li>
           <p><a href="https://garudalinux.org/downloads.html"><span class="label">Garuda</span> <img src="{{ '/images/Garuda-logo-22.png' | relative_url }}" title="Garuda LXQt-Kwin" alt="Garuda Linux"></a></p>
-        </li>
+        </li>-->
         <li>
           <p><a href="https://wiki.gentoo.org/wiki/LXQt"><span class="label">Gentoo</span> <img src="{{ '/images/gentoo-logo-22.png' | relative_url }}" title="Gentoo Wiki" alt="Gentoo"></a></p>
         </li>


### PR DESCRIPTION
Fix small mistake from my previous PR.

Comment out Garuda Linux: currently Garuda [doesn't provide](https://forum.garudalinux.org/t/garuda-lxqt/31976) ISO images with LXQt.