### PR TITLE
Fix links in _includes/downloads.html (again)

### DIFF
--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -30,7 +30,7 @@
             <p><a href="https://sourceforge.net/projects/lxqt-for-chakra/"><span class="label">Chakra</span> <img src="{{ '/images/chakra-logo-22.png' | relative_url }}" title="Chakra" alt="Chakra" /></a></p>
         </li>-->
         <li>
-            <p><a href="https://packages.artixlinux.org/?search_criteria=lxqt"><span class="label">Artix</span> <img src="{{ '/images/artix-logo-22.png' | relative_url }}" title="Artix packages" alt="Artix" /></a></p>
+            <p><a href="https://packages.artixlinux.org/packages/?sort=&q=lxqt"><span class="label">Artix</span> <img src="{{ '/images/artix-logo-22.png' | relative_url }}" title="Artix packages" alt="Artix" /></a></p>
         </li>
         <li>
           <p><a href="https://wiki.debian.org/LXQt"><span class="label">Debian</span> <img src="{{ '/images/debian-logo-22.png' | relative_url }}" title="Debian Wiki" alt="Debian"></a></p>
@@ -66,7 +66,7 @@
           <p><a href="https://abf.openmandriva.org/openmandriva/task-lxqt/build_lists"><span class="label">OpenMandriva</span> <img src="{{ '/images/openmandriva-logo-22.png' | relative_url }}" title="OpenMandriva metapackage" alt="OpenMandriva Lx"></a></p>
         </li>
         <li>
-          <p><a href="http://wiki.rosalab.ru/en/index.php/LXQt"><span class="label">ROSA Linux</span> <img src="{{ '/images/rosa-linux-22.png' | relative_url }}" title="Information about LXQt in ROSA Linux" alt="ROSA Linux"></a></p>
+          <p><a href="https://rosa.ru/rosa-linux-download-links/"><span class="label">ROSA Linux</span> <img src="{{ '/images/rosa-linux-22.png' | relative_url }}" title="Download latest release" alt="ROSA Linux"></a></p>
         </li>
         <li>
           <p><a href="https://en.opensuse.org/Portal:LXQt"><span class="label">openSUSE</span> <img src="{{ '/images/opensuse-logo-22.png' | relative_url }}" title="openSUSE wiki" alt="openSUSE"></a></p>


### PR DESCRIPTION
Note about ROSA: for now there are only [unofficial](https://abf.rosa.ru/platforms/rosa13/products) (AFAIK) ISO images for ROSA Fresh 13 with LXQt. Hopefully they'll make a release at some point.